### PR TITLE
Prepend .bin filenames with entry index

### DIFF
--- a/Dell_PFS_Extract.py
+++ b/Dell_PFS_Extract.py
@@ -674,16 +674,15 @@ def pfs_extract(buffer, pfs_index, pfs_name, pfs_count) :
 
 		# Convert file name in GUID format to human readable name
 		if is_disassemble:
+			guid_name = os.path.join(output_entries_path, "%s-%s.bin" % (file_guid, file_version_org))
+			bios_version_name = os.path.join(output_entries_path, "%s-%s.bin" % (file_name, bios_version))
+			human_readable_name = os.path.join(output_entries_path, "%s-%s.bin" % (f'{entry_index} - {file_name}', file_version_org))
 			if file_type == 'MODEL_INFO' or file_type == 'PFS_INFO' :
 				# Replace GUID by NAME and FILE Version by BIOS Version
-				os.rename(
-					os.path.join(output_entries_path, "%s-%s.bin" % (file_guid, file_version_org)),
-					os.path.join(output_entries_path, "%s-%s.bin" % (file_name, bios_version)))
-			else :
+				os.rename(guid_name, bios_version_name)
+			else:
 				# Replace GUID by NAME only
-				os.rename(
-					os.path.join(output_entries_path, "%s-%s.bin" % (file_guid, file_version_org)),
-					os.path.join(output_entries_path, "%s-%s.bin" % (file_name, file_version_org)))
+				os.rename(guid_name, human_readable_name)
 
 		data_ext = '.data.bin' if is_advanced else '.bin' # Simpler Data Extension for non-advanced users
 		meta_ext = '.meta.bin' if is_advanced else '.bin' # Simpler Metadata Extension for non-advanced users


### PR DESCRIPTION
I've tried using this fork to extract the data from the 1.8.1 and 1.6 upgrades, but it crashed on the line modified in this PR. It seems like the .exes contain some duplicated files under different GUIDs (the MD5 hashes of those files match). When the script tried to rename the first duplicated file, there would already be a file with the same name in the folder, and the script would throw a FileExistsError. The fix here is to prepend the files with an index - that way it's impossible to have two exact same filenames.

It seems like the assembler script doesn't actually look at the filenames, so I'm assuming nothing has changed and the resulting .exe that can be built using the script should still be OK. However, if this code worked before and now it doesn't, it begs the question - have the BIOS update files provided by Dell been modified since this fork was originally created? If so, is there a chance that other things have also been modified, and that the script could need more changes to adapt to those new update files? 🤔 